### PR TITLE
Send via queue defaults to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,8 @@ All notable changes to `exception-notification` will be documented in this file
 ## 1.0.1 - 2020-06-28
 
 - Few bug fixes
+
+## 1.0.3 - 2020-07-02
+
+- Changed the default use of a queue to false.
+- Updated documentation readme.

--- a/README.md
+++ b/README.md
@@ -59,12 +59,14 @@ return [
     | Error email recipients
     |--------------------------------------------------------------------------
     |
-    | Here you can specify the list of recipients
+    | Here you can specify an array of recipients
     |
     */
 
     'toAddresses' => [
-        "bar@example.com"
+        'email1@example.com',
+        'email2@example.com',
+        'email3@example.com',
     ],
 
     /*
@@ -72,14 +74,14 @@ return [
     | Queue customization
     |--------------------------------------------------------------------------
     |
-    | Exception notificaiton will send throuh the queue by default,
-    | Howerver you can customize it as per your needs.
+    | Exception notificaiton will send directly by default,
+    | Howerver you can enable the use of queues and customize it as per your needs.
     |
     */
 
     'queueOptions' => [
-        'enabled' => env('EXCEPTION_NOTIFICATION_SHOULD_QUEUE',true),
-        'queue' => env('EXCEPTION_NOTIFICATION_QUEUE_NAME', "default"),
+        'enabled' => env('EXCEPTION_NOTIFICATION_SHOULD_QUEUE',false),
+        'queue' => env('EXCEPTION_NOTIFICATION_QUEUE_NAME', 'default'),
         'connection' => env('QUEUE_DRIVER', 'redis'),
     ],
 
@@ -114,22 +116,33 @@ return [
     ],
 ];
 
-
 ```
 
 ## Usage
- Add the below line in the report method in App/Exceptions/Handler.php
- 
-``` php
+Add the line following line to the report method in App/Exceptions/Handler.php
 
+```php
+app('exceptionNotification')->reportException($exception);
+```
+
+Once added, the mehod should look something like this:
+
+``` php
   public function report(Exception $exception) {
-    app('exceptionNotification')->reportException($exception); // <-- Add this line
+    app('exceptionNotification')->reportException($exception); // <-- The line you added
     parent::report($exception);
   }
-   
+```
+
+Once Exception-Notification is installed and configured you can trigger a test exception by running:
+
+``` bash
+php artisan exception:throw
 ```
 
 ## Testing
+
+To run tests simply run:
 
 ``` bash
 composer test

--- a/config/exception-notification.php
+++ b/config/exception-notification.php
@@ -37,7 +37,8 @@ return [
     */
 
     'toAddresses' => [
-        'bar@example.com'
+        'email1@example.com',
+        'email2@example.com',
     ],
 
     /*
@@ -51,7 +52,7 @@ return [
     */
 
     'queueOptions' => [
-        'enabled'       => env('EXCEPTION_NOTIFICATION_SHOULD_QUEUE',false),
+        'enabled'       => env('EXCEPTION_NOTIFICATION_SHOULD_QUEUE', false),
         'queue'         => env('EXCEPTION_NOTIFICATION_QUEUE_NAME', 'default'),
         'connection'    => env('QUEUE_DRIVER', 'redis'),
     ],

--- a/config/exception-notification.php
+++ b/config/exception-notification.php
@@ -45,14 +45,14 @@ return [
     | Queue customization
     |--------------------------------------------------------------------------
     |
-    | Exception notificaiton will send throuh the queue by default,
-    | Howerver you can customize it as per your needs.
+    | Exception notificaiton will send directly by default,
+    | Howerver you can enable the use of queues and customize it as per your needs.
     |
     */
 
     'queueOptions' => [
-        'enabled'       => env('EXCEPTION_NOTIFICATION_SHOULD_QUEUE',true),
-        'queue'         => env('EXCEPTION_NOTIFICATION_QUEUE_NAME', "default"),
+        'enabled'       => env('EXCEPTION_NOTIFICATION_SHOULD_QUEUE',false),
+        'queue'         => env('EXCEPTION_NOTIFICATION_QUEUE_NAME', 'default'),
         'connection'    => env('QUEUE_DRIVER', 'redis'),
     ],
 

--- a/tests/ExceptionNotificationTest.php
+++ b/tests/ExceptionNotificationTest.php
@@ -34,7 +34,7 @@ class ExceptionNotificationTest extends TestCase
 
         Mail::assertQueued(ExceptionMailer::class, function ($mail) {
             return strpos($mail->subject, 'The reportable exception.')
-            && $mail->hasTo('bar@example.com');
+            && $mail->hasTo('email1@example.com');
         });
     }
 
@@ -58,6 +58,6 @@ class ExceptionNotificationTest extends TestCase
 
         app('exceptionNotification')->reportException(new ShouldntReportableException());
 
-        Mail::assertNotQueued(ExceptionMailer::class);
+        Mail::assertNotSent(ExceptionMailer::class);
     }
 }

--- a/tests/ExceptionNotificationTest.php
+++ b/tests/ExceptionNotificationTest.php
@@ -26,7 +26,6 @@ class ExceptionNotificationTest extends TestCase
     /** @test */
     public function it_will_send_a_notification_when_an_exception_occurs_with_queue()
     {
-
         config(['exception-notification.queueOptions.enabled' => true]);
 
         Mail::fake();
@@ -44,7 +43,6 @@ class ExceptionNotificationTest extends TestCase
     /** @test */
     public function it_will_send_a_notification_when_an_exception_occurs_without_queue()
     {
-
         Mail::fake();
 
         app('exceptionNotification')->reportException(new ShouldReportableException());

--- a/tests/ExceptionNotificationTest.php
+++ b/tests/ExceptionNotificationTest.php
@@ -49,7 +49,6 @@ class ExceptionNotificationTest extends TestCase
 
         Mail::assertSent(ExceptionMailer::class);
 
-        config(['exception-notification.queueOptions.enabled' => true]);
     }
 
 

--- a/tests/ExceptionNotificationTest.php
+++ b/tests/ExceptionNotificationTest.php
@@ -24,8 +24,9 @@ class ExceptionNotificationTest extends TestCase
     }
 
     /** @test */
-    public function it_will_send_a_notification_when_an_exception_occurs()
+    public function it_will_send_a_notification_when_an_exception_occurs_with_queue()
     {
+
         config(['exception-notification.queueOptions.enabled' => true]);
 
         Mail::fake();
@@ -36,12 +37,13 @@ class ExceptionNotificationTest extends TestCase
             return strpos($mail->subject, 'The reportable exception.')
             && $mail->hasTo('email1@example.com');
         });
+
+        config(['exception-notification.queueOptions.enabled' => false]);
     }
 
     /** @test */
     public function it_will_send_a_notification_when_an_exception_occurs_without_queue()
     {
-        config(['exception-notification.queueOptions.enabled' => false]);
 
         Mail::fake();
 

--- a/tests/ExceptionNotificationTest.php
+++ b/tests/ExceptionNotificationTest.php
@@ -48,7 +48,6 @@ class ExceptionNotificationTest extends TestCase
         app('exceptionNotification')->reportException(new ShouldReportableException());
 
         Mail::assertSent(ExceptionMailer::class);
-
     }
 
 

--- a/tests/ExceptionNotificationTest.php
+++ b/tests/ExceptionNotificationTest.php
@@ -13,7 +13,7 @@ class ExceptionNotificationTest extends TestCase
     public function it_wont_send_a_notification_when_its_disabled()
     {
         config(['exception-notification.enabled' => false]);
-        
+
         Mail::fake();
 
         app('exceptionNotification')->reportException(new ShouldReportableException());
@@ -22,10 +22,12 @@ class ExceptionNotificationTest extends TestCase
 
         config(['exception-notification.enabled' => true]);
     }
-  
+
     /** @test */
     public function it_will_send_a_notification_when_an_exception_occurs()
     {
+        config(['exception-notification.queueOptions.enabled' => true]);
+
         Mail::fake();
 
         app('exceptionNotification')->reportException(new ShouldReportableException());
@@ -40,13 +42,13 @@ class ExceptionNotificationTest extends TestCase
     public function it_will_send_a_notification_when_an_exception_occurs_without_queue()
     {
         config(['exception-notification.queueOptions.enabled' => false]);
-        
+
         Mail::fake();
 
         app('exceptionNotification')->reportException(new ShouldReportableException());
 
         Mail::assertSent(ExceptionMailer::class);
-        
+
         config(['exception-notification.queueOptions.enabled' => true]);
     }
 


### PR DESCRIPTION
Many sites do not have queues running by default. We should mimic that behavior by disabling sending via queue by default.

Also added a little more documentation.